### PR TITLE
Handle shape mismatch during array broadcasting

### DIFF
--- a/export.py
+++ b/export.py
@@ -115,6 +115,8 @@ def model_export(model, filepath, group_size=64):
     p = model.params
     hidden_dim = model.layers[0].feed_forward.w1.weight.shape[0]
     n_kv_heads = p.n_heads if p.n_kv_heads is None else p.n_kv_heads
+    # ensure head_dim in header matches actual model attention head dimension
+    head_dim = model.layers[0].attention.head_dim if hasattr(model.layers[0].attention, 'head_dim') else (p.dim // p.n_heads)
     header = struct.pack(
         "iiiiiiiiii",
         p.dim,
@@ -124,7 +126,7 @@ def model_export(model, filepath, group_size=64):
         n_kv_heads,
         p.vocab_size,
         p.max_seq_len,
-        p.head_dim,
+        head_dim,
         int(shared_classifier),
         group_size
     )


### PR DESCRIPTION
Align `head_dim` in checkpoint header with the model's actual attention head dimension to fix broadcasting errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-08e233bb-2724-4aff-8aba-a2bdd5f5d5e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-08e233bb-2724-4aff-8aba-a2bdd5f5d5e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

